### PR TITLE
Transition from configuring to active by itself once on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ In a sourced terminal, start the driver with
 ros2 launch sick_safevisionary_driver driver_node.launch.py
 ```
 
-This driver implements a *lifecycle node* and needs two additional steps to actually publish data.
+You can list the relevant topics with
+```bash
+ros2 topic list | grep sick_safevisionary
+```
+
+This driver implements a *lifecycle node* which automatically transitions into the active state on bootup.
+The state can also be manually changed for example from an unconfigured state to an active, publishing state using two additional steps on the command line.
 Open another sourced terminal and call
 ```bash
 ros2 lifecycle set /sick_safevisionary configure
 ros2 lifecycle set /sick_safevisionary activate
-```
-You can list the relevant topics with
-```bash
-ros2 topic list | grep sick_safevisionary
 ```
 Here's [more information](./sick_safevisionary_driver/README.md) about driver's lifecycle behavior.

--- a/sick_safevisionary_driver/README.md
+++ b/sick_safevisionary_driver/README.md
@@ -14,7 +14,7 @@ This driver's behavior is roughly as follows:
 
 | State    | Behavior |
 | -------- | ------- |
-| Unconfigured  | This is the state right after the driver starts or after `cleanup` has been called. No topics are advertised and previously advertised topics are removed.|
+| Unconfigured  | No topics are advertised and previously advertised topics are removed.|
 | Inactive | The driver establishes a UDP data connection to the camera and processes sensor data without publishing. |
 | Active    | The driver continuously publishes all camera data with a consistent time stamp across all topics. |
 | Finalized    | The driver has been shutdown and all resources have been cleaned up. All previously advertised topics are removed. |

--- a/sick_safevisionary_driver/launch/driver_node.launch.py
+++ b/sick_safevisionary_driver/launch/driver_node.launch.py
@@ -54,6 +54,7 @@ def generate_launch_description():
         ],
     )
 
+    # Configure the driver once it's launched
     configure_trans_event = EmitEvent(
         event=ChangeState(
             lifecycle_node_matcher=matches_action(driver_node),
@@ -61,6 +62,7 @@ def generate_launch_description():
         )
     )
 
+    # Activate the driver once it's configured correctly
     node_activation_handle = RegisterEventHandler(
         OnStateTransition(
             target_lifecycle_node=driver_node,

--- a/sick_safevisionary_tests/integration_tests/integration_tests.py
+++ b/sick_safevisionary_tests/integration_tests/integration_tests.py
@@ -76,6 +76,8 @@ class IntegrationTest(unittest.TestCase):
 
         We repetitively call `configure` and `cleanup` and check if that works.
         """
+        self.change_state(Transition.TRANSITION_DEACTIVATE)
+        self.change_state(Transition.TRANSITION_CLEANUP)
         for _ in range(3):
             self.change_state(Transition.TRANSITION_CONFIGURE)
             self.change_state(Transition.TRANSITION_CLEANUP)


### PR DESCRIPTION
This pull request enables the driver to directly start (with configuration and activation) on bootup. This way the manual CLI input is no longer required which makes it easier to use. I also changed from Node to LifecycleNode in the LaunchDescription