### PR TITLE
Fix *unstable* builds for *Rolling* and *Iron*

### DIFF
--- a/sick_safevisionary_driver/include/sick_safevisionary_driver/compound_publisher.hpp
+++ b/sick_safevisionary_driver/include/sick_safevisionary_driver/compound_publisher.hpp
@@ -33,7 +33,12 @@
 
 #include <memory>
 
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_MAJOR >= 21
+#include "cv_bridge/cv_bridge.hpp"
+#else
 #include "cv_bridge/cv_bridge.h"
+#endif
 #include "opencv2/opencv.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"


### PR DESCRIPTION
## Steps
- [x] Use ROS version-dependent cv_bridge include. Thanks @gavanderhoorn for suggesting this mechanism [here](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/issues/152#issuecomment-1788662712). This should fix our [warnings](https://build.ros2.org/job/Idev__sick_safevisionary_ros2__ubuntu_jammy_amd64/1/clang-tidy/) in the buildfarm for `Iron` and `Rolling`.