### PR TITLE
(sick_safevisionary_driver) Dont install unused boost libs

### DIFF
--- a/.github/workflows/industrial_ci_humble_action.yml
+++ b/.github/workflows/industrial_ci_humble_action.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 jobs:
   industrial_ci:
     env:
-      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-all-dev'
+      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-dev'
       UPSTREAM_WORKSPACE: 'github:SICKAG/sick_safevisionary_base#main'
       ROSDEP_SKIP_KEYS: 'sick_safevisionary_base'
     strategy:

--- a/.github/workflows/industrial_ci_iron_action.yml
+++ b/.github/workflows/industrial_ci_iron_action.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 jobs:
   industrial_ci:
     env:
-      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-all-dev'
+      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-dev'
       UPSTREAM_WORKSPACE: 'github:SICKAG/sick_safevisionary_base#main'
       ROSDEP_SKIP_KEYS: 'sick_safevisionary_base'
     strategy:

--- a/.github/workflows/industrial_ci_rolling_action.yml
+++ b/.github/workflows/industrial_ci_rolling_action.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   industrial_ci:
     env:
-      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-all-dev'
+      BEFORE_BUILD_TARGET_WORKSPACE: 'sudo apt-get install -y libboost-dev'
       UPSTREAM_WORKSPACE: 'github:SICKAG/sick_safevisionary_base#main'
       ROSDEP_SKIP_KEYS: 'sick_safevisionary_base'
     strategy:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  BEFORE_BUILD_UPSTREAM_WORKSPACE: "sudo apt-get install -y libboost-all-dev"
+  BEFORE_BUILD_UPSTREAM_WORKSPACE: "sudo apt-get install -y libboost-dev"
   UPSTREAM_WORKSPACE: ".upstream_workspace.yaml"
   ROSDEP_SKIP_KEYS: "sick_safevisionary_base"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is the official ROS2 driver for the [Sick safeVisionary2](https://www.sick.
 We use *Boost*'s [lock-free](https://www.boost.org/doc/libs/1_82_0/doc/html/lockfree.html) data structures in this driver.
 You can install them with
 ```bash
-sudo apt-get install libboost-all-dev
+sudo apt-get install libboost-dev
 ```
 
 ## Build and install

--- a/sick_safevisionary_driver/package.xml
+++ b/sick_safevisionary_driver/package.xml
@@ -11,8 +11,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libboost-dev</build_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
   <depend>cv_bridge</depend>
-  <depend>libboost-dev</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/sick_safevisionary_driver/package.xml
+++ b/sick_safevisionary_driver/package.xml
@@ -11,8 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>cv_bridge</depend>
+  <depend>libboost-dev</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>


### PR DESCRIPTION
Currently the driver installs all boost libraries for build and final package runtime
This package uses only boost lockfree that is header only, and doesnt need any boost library at runtime.

This PR updates the dependencies declared in the `package.xml`:
- Retrict the boost dependencies for building this package or packages depending only to install only boost headers but not the libraries
- Don't installl boost at runtime


This allows to reduce the disk footrpint of building / using this package.
For building it saves 321MB
For running it saves 482MB


<details><summary> Install footprint before this PR:</summary>

```

# rosdep install -s --from-paths src --ignore-src .
#[apt] Installation commands:
  apt-get install libboost-all-dev
  apt-get install ros-rolling-cv-bridge
  apt-get install ros-rolling-sick-safevisionary-base

# apt install ros-rolling-cv-bridge ros-rolling-sick-safevisionary-base libboost-all-dev --no-install-recommends
0 upgraded, 423 newly installed, 0 to remove and 0 not upgraded.
Need to get 316 MB of archives.
After this operation, 1502 MB of additional disk space will be used.
```

</details>

## With this PR

<details><summary> Build time footprint:</summary>

```
# rosdep install -s --from-paths src --ignore-src . --dependency-types build
#[apt] Installation commands:
  apt-get install ros-rolling-cv-bridge
  apt-get install ros-rolling-sick-safevisionary-base
  apt-get install libboost-dev

# apt install ros-rolling-cv-bridge ros-rolling-sick-safevisionary-base libboost-dev --no-install-recommends
0 upgraded, 294 newly installed, 0 to remove and 0 not upgraded.
Need to get 259 MB of archives.
After this operation, 1181 MB of additional disk space will be used.
```

</details>

<details><summary> Runtime footprint:</summary>

```
# rosdep install -s --from-paths src --ignore-src . --dependency-types exec
#[apt] Installation commands:
  apt-get install ros-rolling-cv-bridge
  apt-get install ros-rolling-sick-safevisionary-base

# apt-get install --no-install-recommends ros-rolling-cv-bridge ros-rolling-sick-safevisionary-base
0 upgraded, 292 newly installed, 0 to remove and 0 not upgraded.
Need to get 248 MB of archives.
After this operation, 1020 MB of additional disk space will be used.
```

</details>